### PR TITLE
feat: add SPARQL item list input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1647,6 +1647,15 @@
         "@types/node": "*"
       }
     },
+    "@types/codemirror": {
+      "version": "0.0.108",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
+      "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
+      "dev": true,
+      "requires": {
+        "@types/tern": "*"
+      }
+    },
     "@types/connect": {
       "version": "3.4.34",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
@@ -1670,6 +1679,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
       "dev": true
     },
     "@types/express": {
@@ -1757,6 +1772,15 @@
       "dev": true,
       "requires": {
         "jest-diff": "^24.3.0"
+      }
+    },
+    "@types/jquery": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.5.tgz",
+      "integrity": "sha512-6RXU9Xzpc6vxNrS6FPPapN1SxSHgQ336WC6Jj/N8q30OiaBZ00l1GBgeP7usjVZPivSkGUfL1z/WW6TX989M+w==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
       }
     },
     "@types/json-schema": {
@@ -1875,6 +1899,15 @@
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
     },
+    "@types/tern": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
+      "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
     "@types/tiny-async-pool": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/tiny-async-pool/-/tiny-async-pool-1.0.0.tgz",
@@ -1897,6 +1930,12 @@
           "dev": true
         }
       }
+    },
+    "@types/underscore": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.0.tgz",
+      "integrity": "sha512-ipNAQLgRnG0EWN1cTtfdVHp5AyTW/PAMJ1PxLN4bAKSHbusSZbj48mIHiydQpN7GgQrYqwfnvZ573OVfJm5Nzg==",
+      "dev": true
     },
     "@types/webpack": {
       "version": "4.41.26",
@@ -2903,6 +2942,11 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wikimedia/jquery.i18n": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@wikimedia/jquery.i18n/-/jquery.i18n-1.0.7.tgz",
+      "integrity": "sha512-bzQbF3JoYsC2paYfvY9DGRcDJVtDX+ru27QW7jsL+NB1mvTwiXPm5M6r5LpVbdxx/c/2uxKTt5PVRAekoh2uGA=="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -3827,6 +3871,16 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
       "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
     },
+    "bootstrap-table": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.18.2.tgz",
+      "integrity": "sha512-BShrYY9bcadwxikP5Sd/+tZlbLcYqOBjYm5bdJLu3lRTgXEQ1p937ZNlcCMhIrRhvelUKlSl7EFORnEkSHR7gA=="
+    },
+    "bootstrap-toggle": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bootstrap-toggle/-/bootstrap-toggle-2.2.2.tgz",
+      "integrity": "sha1-K4hTT8G5mGdPh3+Yug2LW3Q+lv4="
+    },
     "bootstrap-vue": {
       "version": "2.21.2",
       "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.21.2.tgz",
@@ -4407,6 +4461,11 @@
         }
       }
     },
+    "cldrpluralruleparser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/cldrpluralruleparser/-/cldrpluralruleparser-1.3.2.tgz",
+      "integrity": "sha512-z+/RRFz5oMy7nglARs8D+uQhqOIwobNHJwdGBp0nDFpQXVUbVEf80VDQ8xW0ifiEldyWdpylJxLNMcQCAq2esg=="
+    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -4693,6 +4752,11 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "codemirror": {
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.60.0.tgz",
+      "integrity": "sha512-AEL7LhFOlxPlCL8IdTcJDblJm8yrAGib7I+DErJPdZd4l6imx8IMgKK3RblVgBQqz3TZJR4oknQ03bz+uNjBYA=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -5156,8 +5220,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "6.0.0",
@@ -5699,6 +5762,11 @@
         }
       }
     },
+    "d3": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -6102,6 +6170,11 @@
         }
       }
     },
+    "dimple-js": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/dimple-js/-/dimple-js-2.1.4.tgz",
+      "integrity": "sha1-afhPKyJpR/o62PS3ZjOfrMPjxDE="
+    },
     "dir-glob": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
@@ -6239,6 +6312,11 @@
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
     },
+    "downloadjs": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.4.tgz",
+      "integrity": "sha1-VqZT+tTenxyHuBa0H6DOuu7WUyk="
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -6315,6 +6393,11 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
       "dev": true
     },
+    "ekko-lightbox": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ekko-lightbox/-/ekko-lightbox-5.3.0.tgz",
+      "integrity": "sha512-mbacwySuVD3Ad6F2hTkjSTvJt59bcVv2l/TmBerp4xZnLak8tPtA4AScUn4DL42c1ksTiAO6sGhJZ52P/1Qgew=="
+    },
     "electron-to-chromium": {
       "version": "1.3.671",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.671.tgz",
@@ -6349,6 +6432,11 @@
           "dev": true
         }
       }
+    },
+    "emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -6465,6 +6553,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-shim": {
+      "version": "0.35.6",
+      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.6.tgz",
+      "integrity": "sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -7487,6 +7580,11 @@
       "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
       "dev": true
     },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -7899,6 +7997,14 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gijgo": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/gijgo/-/gijgo-1.9.6.tgz",
+      "integrity": "sha512-4hvFGeAWB0IEC/xBr5BCKhgyAN7dAUifk8ihdtysB/V/1Mi39fu3Fw0yODr20NPTiLB5Ea9NTpjIQyZk7qgZUw==",
+      "requires": {
+        "jquery": "^3.2.1"
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -7982,6 +8088,10 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
+    "grunt-merge-i18n": {
+      "version": "git+https://github.com/wikimedia/grunt-merge-i18n.git#abb919384593d893b91e9127f389490526834adf",
+      "from": "git+https://github.com/wikimedia/grunt-merge-i18n.git"
+    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -7991,6 +8101,11 @@
         "duplexer": "^0.1.1",
         "pify": "^4.0.1"
       }
+    },
+    "hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -8599,8 +8714,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.8",
@@ -9206,8 +9320,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -10031,6 +10144,34 @@
         }
       }
     },
+    "jqcloud2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/jqcloud2/-/jqcloud2-2.0.3.tgz",
+      "integrity": "sha1-mxaR+FUT0pAqXsY+rUkxi4WgxHg=",
+      "requires": {
+        "jquery": ">= 1.9.0"
+      }
+    },
+    "jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+    },
+    "jquery-resizable-dom": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/jquery-resizable-dom/-/jquery-resizable-dom-0.20.0.tgz",
+      "integrity": "sha1-9uQoy0E3YKKsONN3npyjh0/7EZo="
+    },
+    "jquery-toast-plugin": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/jquery-toast-plugin/-/jquery-toast-plugin-1.3.2.tgz",
+      "integrity": "sha512-0j/nfqA2FHFuJXp8QL33EVVCY//TDVfq4LULhTbasZYl2aZlX6YiSF5IGrI31dQiS9S4JkXBUfX3rMJcfl/u/g=="
+    },
+    "jquery.uls": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jquery.uls/-/jquery.uls-0.1.0.tgz",
+      "integrity": "sha512-z/BwziIW0i2CRTWUlnp+HP4x7io/EUxvygPUnZxP2GC1Pz/sOxa5Ke9TlsPcoCW1yZshAlSgc9Jn3uchePR5Sg=="
+    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -10057,6 +10198,11 @@
           "dev": true
         }
       }
+    },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "js-message": {
       "version": "1.0.7",
@@ -10215,6 +10361,19 @@
         "verror": "1.10.0"
       }
     },
+    "jstree": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/jstree/-/jstree-3.3.11.tgz",
+      "integrity": "sha512-9ZJKroPjCyjb6JLPuAbBrLJKT6pS1f4m5gkwoEagG5oQWtvzm0IiDsntXTxeFtz7AmqrKfij+gLfF9MgWriNxg==",
+      "requires": {
+        "jquery": ">=1.9.1"
+      }
+    },
+    "keycharm": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
+      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -10263,6 +10422,36 @@
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
       "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
       "dev": true
+    },
+    "leaflet": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+    },
+    "leaflet-fullscreen": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/leaflet-fullscreen/-/leaflet-fullscreen-1.0.2.tgz",
+      "integrity": "sha1-CcYcS6xF9jsu4Sav2H5c2XZQ/Bs="
+    },
+    "leaflet-minimap": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/leaflet-minimap/-/leaflet-minimap-3.6.1.tgz",
+      "integrity": "sha1-KkP/Oz2UekWgrPS978llBbZzpsY="
+    },
+    "leaflet-zoombox": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/leaflet-zoombox/-/leaflet-zoombox-0.5.2.tgz",
+      "integrity": "sha512-XizyOGMe58c4L8eNAzeIwtgj8EiY+BTAuc8YNLQ63o6bvfFYLGl1rU2T5by8Qr8WowouGNTNpXbs4OONtsY1lQ=="
+    },
+    "leaflet.locatecontrol": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.62.0.tgz",
+      "integrity": "sha512-coatKzdlrWAnlrOyy+38K9VhcSs/r/UDH32Q+mD07wvNAzrfBiaVYJhtHfqUWsVU8xKRuza/1nMbWWH54Ey6Sw=="
+    },
+    "leaflet.markercluster": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.0.tgz",
+      "integrity": "sha512-Fvf/cq4o806mJL50n+fZW9+QALDDLPvt7vuAjlD2vfnxx3srMDs2vWINJze4nKYJYRY45OC6tM/669C3pLwMCA=="
     },
     "left-pad": {
       "version": "1.3.0",
@@ -11424,6 +11613,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "mathjax": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.1.2.tgz",
+      "integrity": "sha512-BojKspBv4nNWzO1wC6VEI+g9gHDOhkaGHGgLxXkasdU4pwjdO5AXD5M/wcLPkXYPjZ/N+6sU8rjQTlyvN2cWiQ=="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -11749,8 +11943,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.3",
@@ -11847,8 +12040,7 @@
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -13665,6 +13857,14 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "propagating-hammerjs": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-1.5.0.tgz",
+      "integrity": "sha512-3PUXWmomwutoZfydC+lJwK1bKCh6sK6jZGB31RUX6+4EXzsbkDZrK4/sVR7gBrvJaEIwpTVyxQUAd29FKkmVdw==",
+      "requires": {
+        "hammerjs": "^2.0.8"
+      }
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -14545,6 +14745,11 @@
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
+    },
+    "select2": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
+      "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
     },
     "selfsigned": {
       "version": "1.10.8",
@@ -16153,8 +16358,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
       "version": "3.9.9",
@@ -16185,6 +16389,11 @@
           "dev": true
         }
       }
+    },
+    "underscore": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -16412,8 +16621,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.1.1",
@@ -16483,6 +16691,18 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vis": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/vis/-/vis-4.21.0.tgz",
+      "integrity": "sha1-3XFji/9/ZJXQC8n0DCU1JhM97Ws=",
+      "requires": {
+        "emitter-component": "^1.1.1",
+        "hammerjs": "^2.0.8",
+        "keycharm": "^0.2.0",
+        "moment": "^2.18.1",
+        "propagating-hammerjs": "^1.4.6"
       }
     },
     "vm-browserify": {
@@ -17269,6 +17489,50 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
+    "wellknown": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wellknown/-/wellknown-0.5.0.tgz",
+      "integrity": "sha1-Ca6YcfqCbPCm7BU37wDDedeNcQE=",
+      "requires": {
+        "concat-stream": "~1.5.0",
+        "minimist": "~1.2.0"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+          "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
+          }
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -17317,6 +17581,57 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wikidata-query-gui": {
+      "version": "git+https://github.com/wikimedia/wikidata-query-gui.git#a12539cf0c10f55964366ec9054dd27f9d9223a5",
+      "from": "git+https://github.com/wikimedia/wikidata-query-gui.git",
+      "requires": {
+        "@wikimedia/jquery.i18n": "^1.0.5",
+        "bootstrap": "^3.4.1",
+        "bootstrap-table": "^1.18.2",
+        "bootstrap-toggle": "^2.2.2",
+        "cldrpluralruleparser": "^1.3.2",
+        "codemirror": "^5.59.2",
+        "d3": "^3.5.17",
+        "dimple-js": "^2.1.4",
+        "downloadjs": "1.4.4",
+        "ekko-lightbox": "^5.3.0",
+        "es6-shim": "^0.35.6",
+        "font-awesome": "^4.7.0",
+        "gijgo": "1.9.6",
+        "grunt-merge-i18n": "git+https://github.com/wikimedia/grunt-merge-i18n.git",
+        "jqcloud2": "^2.0.3",
+        "jquery": "^3.4.1",
+        "jquery-resizable-dom": "^0.20.0",
+        "jquery-toast-plugin": "^1.3.2",
+        "jquery.uls": "^0.1.0",
+        "js-cookie": "^2.2.0",
+        "jstree": "^3.3.11",
+        "leaflet": "^1.7.1",
+        "leaflet-fullscreen": "^1.0.2",
+        "leaflet-minimap": "^3.6.1",
+        "leaflet-zoombox": "^0.5.0",
+        "leaflet.locatecontrol": "^0.62.0",
+        "leaflet.markercluster": "^1.3.0",
+        "mathjax": "^3.1.2",
+        "moment": "^2.29.1",
+        "select2": "^4.0.8",
+        "underscore": "^1.12.0",
+        "vis": "^4.21.0",
+        "wellknown": "^0.5.0"
+      },
+      "dependencies": {
+        "bootstrap": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+          "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
+        },
+        "moment": {
+          "version": "2.29.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+          "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+        }
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -11,20 +11,27 @@
   },
   "dependencies": {
     "bootstrap-vue": "^2.17.3",
+    "codemirror": "^5.60.0",
     "core-js": "^3.6.5",
+    "jquery": "^3.6.0",
     "papaparse": "^5.3.0",
     "tiny-async-pool": "^1.2.0",
+    "underscore": "^1.12.1",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.2.0",
-    "vuex": "^3.4.0"
+    "vuex": "^3.4.0",
+    "wikidata-query-gui": "git+https://github.com/wikimedia/wikidata-query-gui.git"
   },
   "devDependencies": {
     "@babel/polyfill": "^7.11.5",
+    "@types/codemirror": "0.0.108",
     "@types/jest": "^24.0.19",
+    "@types/jquery": "^3.5.5",
     "@types/papaparse": "^5.2.5",
     "@types/tiny-async-pool": "^1.0.0",
+    "@types/underscore": "^1.11.0",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,11 @@
 <template>
   <div id="app">
     <b-container class="mt-4 mb-4">
-      <a href="https://www.wikidata.org/" target="_blank"
-        ><img
-          class="logo mb-2"
-          src="https://upload.wikimedia.org/wikipedia/commons/6/66/Wikidata-logo-en.svg"
-        />
-      </a>
-      <h1>Item Quality Evaluator</h1>
+      <img
+        class="logo mb-2"
+        src="https://upload.wikimedia.org/wikipedia/commons/6/66/Wikidata-logo-en.svg"
+      />
+      <h1>Item Quality Evaluator Tool</h1>
       <router-view />
     </b-container>
   </div>
@@ -20,6 +18,15 @@ img.logo {
 </style>
 <script lang="ts">
 import Vue from "vue";
+import CodeMirror from "codemirror";
 import "@/assets/styles.scss";
+
+/**
+ * Attach CodeMirror to the window instance to support the wikidata-query-gui library
+ * Init an empty object on the window for the wikidata-query-gui to attach itself onto
+ *  */
+window.CodeMirror = CodeMirror;
+window.wikibase = {};
+
 export default Vue.extend({});
 </script>

--- a/src/ArticleQualityService.ts
+++ b/src/ArticleQualityService.ts
@@ -148,7 +148,9 @@ class ArticleQualityService {
     try {
       return await fetch(queryUrl)
         .then(data => data.json())
-        .then(response => response.wikidatawiki.scores);
+        .then(
+          response => response.wikidatawiki && response.wikidatawiki.scores
+        );
     } catch (e) {
       throw "ORES Error: " + e.message;
     }

--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -9,49 +9,34 @@ $secondary:$light;
 @import "~bootstrap-vue/src/index.scss";
 
 .btn-primary {
-    font-weight: 700;
-}
-
-.btn-secondary {
-    font-weight: 700;
-    border: 1px solid #a2a9b1;
-    color:black;
-    background:$secondary;
-    &:hover{
-        background: white;
-        color: #404244;
-        border-color:#a2a9b1
-    }
-    &:focus{
-        border-color: $blue;
-        background-color:$light;
-    }
+  font-weight: 700;
+  font-size: 1.125rem;
 }
 
 .btn-light {
-    border: 1px solid #a2a9b1;
-    &:hover {
-        background-color: $white;
-    }
+  border: 1px solid #a2a9b1;
+  &:hover {
+    background-color: $white;
+  }
 }
 
 body {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    color: #202122;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: #202122;
 }
 
 h1 {
-    font-family: Georgia, Times, serif;
-    font-size: 2rem;
+  font-family: Georgia, Times, serif;
+  font-size: 2rem;
 }
 
 h2 {
-    font-weight: 700;
-    font-size: 1.125rem;
-    line-height: 1.3;
+  font-weight: 700;
+  font-size: 1.125rem;
+  line-height: 1.3;
 }
 
 p {
-    font-size: 0.875rem;
+  font-size: 0.875rem;
 }

--- a/src/components/ItemIdentifierList.vue
+++ b/src/components/ItemIdentifierList.vue
@@ -1,29 +1,24 @@
 <template>
-  <div class="mt-4">
-    <h2>For which Items should the average score be calculated?</h2>
-    <b-card class="mt-4">
-      <b-textarea
-        @keydown="onKeyDown"
-        @paste="onPaste"
-        v-model="itemList"
-        v-bind:readonly="loading"
-      />
-      <p>One Item-identifier (like Q12345) on each line</p>
-      <b-row align-h="end" no-gutters>
-        <b-button
-          @click="getRevisions(itemList)"
-          class="mt-2"
-          variant="primary"
-          v-bind:disabled="loading"
-        >
-          <b-icon-three-dots
-            v-if="loading"
-            animation="cylon"
-          ></b-icon-three-dots>
-          Assess Item Quality
-        </b-button>
-      </b-row>
-    </b-card>
+  <div>
+    <b-textarea
+      @keydown="onKeyDown"
+      @paste="onPaste"
+      v-model="itemList"
+      v-bind:readonly="loading"
+    />
+    <p class="mt-2">One Item-identifier (like Q1234) on each line</p>
+    <b-row align-h="end" no-gutters>
+      <b-button
+        @click="getRevisions(itemList)"
+        class="mt-2"
+        id="get-results"
+        variant="primary"
+        v-bind:disabled="loading || !itemList"
+      >
+        <b-icon-three-dots v-if="loading" animation="cylon"></b-icon-three-dots>
+        Assess Item Quality
+      </b-button>
+    </b-row>
   </div>
 </template>
 
@@ -34,24 +29,20 @@ import store from "@/store";
 import { BIconThreeDots } from "bootstrap-vue";
 
 const AlphaNumericAndNewlineRegex = /[^a-zA-Z0-9\n]/;
+export const ITEM_LIST_KEY = "wikidata.itemQuality.ui.itemList";
 
 export default Vue.extend({
   data() {
     return {
-      itemList: ``
+      itemList: localStorage[ITEM_LIST_KEY]
     };
   },
   components: {
     BIconThreeDots
   },
-  mounted() {
-    if (localStorage.itemList) {
-      this.itemList = localStorage.itemList;
-    }
-  },
   watch: {
     itemList(newItemList) {
-      localStorage.itemList = newItemList;
+      localStorage[ITEM_LIST_KEY] = newItemList;
     }
   },
   computed: {

--- a/src/components/SPARQLEditor.vue
+++ b/src/components/SPARQLEditor.vue
@@ -1,0 +1,173 @@
+<template>
+  <div>
+    <div class="border">
+      <textarea id="sparql"></textarea>
+    </div>
+    <p class="mt-2">
+      You can also prepare your SPARQL query in the
+      <a href="https://query.wikidata.org" target="_blank">QueryService</a> and
+      copy it here
+    </p>
+    <b-row align-h="end" no-gutters>
+      <b-button
+        @click="getRevisions()"
+        class="mt-2"
+        id="get-results"
+        variant="primary"
+        v-bind:disabled="loading"
+      >
+        <b-icon-three-dots v-if="loading" animation="cylon"></b-icon-three-dots>
+        Assess Item Quality
+      </b-button>
+    </b-row>
+  </div>
+</template>
+
+<script>
+import ArticleQualityService from "@/ArticleQualityService";
+import { BIconThreeDots } from "bootstrap-vue";
+import store from "@/store";
+import "codemirror/lib/codemirror.css";
+import "codemirror/mode/sparql/sparql.js";
+import "codemirror/addon/hint/show-hint.js";
+import "codemirror/addon/display/placeholder.js";
+import "codemirror/addon/display/fullscreen.js";
+import "codemirror/addon/hint/show-hint.css";
+import "wikidata-query-gui/wikibase/queryService/ui/i18n/getMessage.js";
+import "wikidata-query-gui/wikibase/queryService/ui/editor/hint/Sparql.js";
+import "wikidata-query-gui/wikibase/queryService/ui/editor/hint/Rdf.js";
+import "wikidata-query-gui/wikibase/queryService/ui/editor/tooltip/Rdf.js";
+import "wikidata-query-gui/wikibase/queryService/ui/editor/Editor.js";
+import "wikidata-query-gui/wikibase/queryService/api/Wikibase.js";
+import "wikidata-query-gui/wikibase/queryService/RdfNamespaces.js";
+import "wikidata-query-gui/wikibase/queryService/ui/editor/Editor.js";
+import "wikidata-query-gui/wikibase/queryService/RdfNamespaces.js";
+import "wikidata-query-gui/wikibase/queryService/api/Sparql.js";
+
+const SPARQL_EDITOR_KEY = "wikibase.queryService.ui.Editor";
+
+export default {
+  components: {
+    BIconThreeDots
+  },
+  mounted: function() {
+    this.editor = new window.wikibase.queryService.ui.editor.Editor();
+    this.service = new window.wikibase.queryService.api.Sparql();
+    this.editor.fromTextArea(this.$el.querySelector("textarea"));
+    this.editor.setValue(localStorage.getItem(SPARQL_EDITOR_KEY));
+    setTimeout(() => this.editor.refresh(), 200);
+  },
+  computed: {
+    results() {
+      return store.state.results;
+    },
+    loading() {
+      return store.state.loading;
+    }
+  },
+  methods: {
+    async getRevisions() {
+      const value = this.editor.getValue();
+      store.commit("setLoading", true);
+
+      try {
+        const response = await this.service.query(value);
+        const results = response.results.bindings;
+
+        const list = Object.values(results).map(result => {
+          const res = result.item.value.split("/");
+          return res[res.length - 1];
+        });
+
+        const aq = new ArticleQualityService();
+        const articleQuality = await aq.calculateArticleQuality(list);
+        store.commit("updateResults", articleQuality);
+        store.commit("setLoading", false);
+
+        this.$router.push({ path: "/results" });
+      } catch (e) {
+        console.log("ERROR", e);
+        store.commit("setLoading", false);
+        if (e.status === 400) {
+          store.commit(
+            "setError",
+            "There was a problem parsing your query. Please check your query is valid and try again"
+          );
+        } else {
+          store.commit("setError", true);
+        }
+      }
+    }
+  }
+};
+</script>
+
+<style lang="scss">
+// Colors for CodeMirror from wikidata-query-gui
+$wmui-color-base70: #c8ccd1; // = HSB 213°, 4%, 82%
+
+$wmui-color-accent30: #2a4b8d; // = HSB 220°, 70%, 55%
+$wmui-color-base30: #72777d; // = HSB 210°, 9%, 49%; WCAG 2.0 level AA at 4.52:1 contrast ratio on `#fff`
+$wmui-color-red30: #b32424; // = HSB 360°, 80%, 70%
+$wmui-color-yellow30: #ac6600; // = HSB 36°, 100%, 67%
+$wmui-color-green30: #14866d; // = HSB 167°, 85%, 53%
+
+$codemirror-color-atom: $wmui-color-accent30;
+$codemirror-color-builtin: $wmui-color-red30;
+$codemirror-color-comment: $wmui-color-base30;
+$codemirror-color-keyword: $codemirror-color-builtin;
+$codemirror-color-string: $wmui-color-yellow30;
+$codemirror-color-variable-2: $wmui-color-green30;
+
+.panel {
+  border: 1px solid $wmui-color-base70;
+  background: white;
+  border-radius: 4px;
+}
+
+.CodeMirror {
+  .cm-atom {
+    color: $codemirror-color-atom;
+  }
+
+  .cm-bracket {
+    color: inherit;
+  }
+
+  .cm-builtin {
+    color: $codemirror-color-builtin;
+  }
+
+  .cm-comment {
+    color: $codemirror-color-comment;
+  }
+
+  .cm-keyword {
+    color: $codemirror-color-keyword;
+  }
+
+  .cm-operator {
+    color: inherit;
+  }
+
+  .cm-string {
+    color: $codemirror-color-string;
+  }
+
+  .cm-variable-2 {
+    color: $codemirror-color-variable-2;
+  }
+
+  &-scroll {
+    min-height: 320px;
+  }
+
+  &-hints {
+    direction: ltr;
+  }
+
+  &-hint {
+    max-width: 19em;
+  }
+}
+</style>

--- a/src/shims-tsx.d.ts
+++ b/src/shims-tsx.d.ts
@@ -10,4 +10,9 @@ declare global {
       [elem: string]: any;
     }
   }
+
+  interface Window {
+    CodeMirror: any;
+    wikibase: any;
+  }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,7 +10,7 @@ interface StoreState {
   unprocessedItems: Array<string>;
   userHasQueried: boolean;
   loading: boolean;
-  error: boolean;
+  error: string | null;
 }
 
 export default new Vuex.Store<StoreState>({
@@ -20,7 +20,7 @@ export default new Vuex.Store<StoreState>({
     unprocessedItems: [],
     userHasQueried: false,
     loading: false,
-    error: false
+    error: null
   },
   mutations: {
     updateResults(state, payload) {
@@ -31,11 +31,16 @@ export default new Vuex.Store<StoreState>({
     },
     setLoading(state, payload) {
       if (payload) {
-        state.error = false;
+        state.error = null;
       }
       state.loading = payload;
     },
     setError(state, payload) {
+      if (payload === true) {
+        state.error =
+          "There was a problem parsing the results from the APIs. This is probably a problem with our code. If you know how, report the issue at [link]";
+        return;
+      }
       state.error = payload;
     }
   },

--- a/src/views/ItemInput.vue
+++ b/src/views/ItemInput.vue
@@ -3,27 +3,60 @@
     <p>
       This tool calculates the average quality score of several Wikidata Items.
     </p>
-    <ItemIdentifierList />
-    <b-alert variant="danger" v-bind:show="error"
-      >An error occurred while processing your request</b-alert
-    >
+    <div class="mt-4">
+      <h2 class="mb-4">
+        For which Items should the average score be calculated?
+      </h2>
+      <b-tabs
+        v-model="activeItemsInputTab"
+        content-class="bg-light p-4 border-bottom border-left border-right relative"
+      >
+        <b-tab title="Item list" lazy>
+          <ItemIdentifierList />
+        </b-tab>
+        <b-tab title="SPARQL" lazy>
+          <SPARQLEditor />
+        </b-tab>
+      </b-tabs>
+      <b-alert variant="danger" v-bind:show="!!error">{{ error }}</b-alert>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Vue } from "vue-property-decorator";
 import ItemIdentifierList from "@/components/ItemIdentifierList.vue"; // @ is an alias to /src
+import SPARQLEditor from "@/components/SPARQLEditor.vue";
 import store from "@/store";
 
-@Component({
+export const ACTIVE_TAB_KEY = "wikidata.itemQuality.ui.activeItemsInputTab";
+
+export default Vue.extend({
   components: {
-    ItemIdentifierList
+    ItemIdentifierList,
+    SPARQLEditor
+  },
+  data() {
+    return {
+      activeItemsInputTab: Number(localStorage[ACTIVE_TAB_KEY])
+    };
+  },
+  watch: {
+    activeItemsInputTab(newActiveTab) {
+      store.commit("setError", null);
+      localStorage[ACTIVE_TAB_KEY] = newActiveTab;
+    }
   },
   computed: {
     error() {
       return store.state.error;
     }
   }
-})
-export default class ItemInput extends Vue {}
+});
 </script>
+<style lang="scss">
+.nav-tabs .nav-link.active {
+  background-color: var(--light);
+  border-bottom-color: var(--light);
+}
+</style>

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -1,13 +1,12 @@
 <template>
   <div class="about">
     <router-link to="/"
-      ><b-button variant="secondary" class="mb-4 mt-2"
-        ><b-icon-chevron-left class="mr-2"></b-icon-chevron-left>Refine item
-        selection</b-button
+      ><b-button variant="light" class="mb-4 mt-2"
+        >← Refine Item selection</b-button
       ></router-link
     >
     <p>
-      Average quality score based on the {{ results.length }} item{{
+      Average quality score based on the {{ results.length }} Item{{
         results.length > 1 ? `s` : ``
       }}
       selected:
@@ -60,14 +59,13 @@ import Vue from "vue";
 import store from "@/store";
 import ResultsTable from "@/components/ResultsTable.vue";
 import CSVGenerator from "@/components/CSVGenerator.vue";
-import { BIconExclamationTriangleFill, BIconChevronLeft } from "bootstrap-vue";
+import { BIconExclamationTriangleFill } from "bootstrap-vue";
 
 export default Vue.extend({
   components: {
     ResultsTable,
     CSVGenerator,
-    BIconExclamationTriangleFill,
-    BIconChevronLeft
+    BIconExclamationTriangleFill
   },
   beforeRouteEnter(to, from, next) {
     // Navigate home if entering /results without making a query

--- a/tests/e2e/specs/test.js
+++ b/tests/e2e/specs/test.js
@@ -10,10 +10,10 @@ afterEach(() => {
   cy.saveLocalStorage();
 });
 
-describe("Item Quality Evaluator Test", () => {
+describe("Item List", () => {
   it("Visits the app root url", () => {
     cy.visit("/");
-    cy.contains("h1", "Item Quality Evaluator");
+    cy.contains("h1", "Item Quality Evaluator Tool");
   });
 
   it("User can input Items", () => {
@@ -37,9 +37,36 @@ describe("Item Quality Evaluator Test", () => {
   });
 
   it("The Item list is stored in localStorage", () => {
-    expect(localStorage.getItem("itemList")).to.be.equal(
-      "Q67\nQ234\nQ1234\nQ154"
-    );
+    expect(
+      localStorage.getItem("wikidata.itemQuality.ui.itemList")
+    ).to.be.equal("Q67\nQ234\nQ1234\nQ154");
+  });
+
+  it("Should get the results for the Items", () => {
+    cy.getResults();
+  });
+});
+
+describe("SPARQL Query", () => {
+  const testQuery = `#Cats\n  \nSELECT ?item ?itemLabel \nWHERE\n{\n  ?item wdt:P31 wd:Q146.\n  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }\n}`;
+
+  it("Visits the app root url", () => {
+    cy.visit("/");
+    cy.contains("h1", "Item Quality Evaluator Tool");
+  });
+
+  it("User can open the SPARQL input tab", () => {
+    cy.contains("SPARQL").click();
+  });
+
+  it("User can input a SPARQL query", () => {
+    cy.get(".CodeMirror textarea").type(testQuery, {
+      parseSpecialCharSequences: false
+    });
+  });
+
+  it("The Item list is stored in localStorage", () => {
+    expect(localStorage.getItem("wikibase.queryService.ui.Editor")).to.exist;
   });
 
   it("Should get the results for the Items", () => {

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -3,7 +3,7 @@ Cypress.Commands.add("inputItemList", text => {
 });
 
 Cypress.Commands.add("getResults", () => {
-  cy.get("button").click();
+  cy.get("button#get-results").click();
   cy.url().should("include", "/results");
 });
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,8 +1,20 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const webpack = require("webpack");
+
 module.exports = {
   chainWebpack: config => {
     config.plugin("html").tap(args => {
-      args[0].title = "Item Quality Evaluator | Wikidata";
+      args[0].title = "Item Quality Evaluator Tool | Wikidata";
       return args;
     });
+  },
+  configureWebpack: {
+    plugins: [
+      new webpack.ProvidePlugin({
+        $: "jquery",
+        jQuery: "jquery",
+        _: "underscore"
+      })
+    ]
   }
 };


### PR DESCRIPTION
Adds funcitonality to use SPARQL as an input for the item list.

Uses the wikidata-query-gui package

Phabricator Ticket:
[T275316 - Start with a SPARQL query instead of a list of Item IDs](https://phabricator.wikimedia.org/T275316)